### PR TITLE
Improved section-header class styling globally(#27xkdzq)

### DIFF
--- a/changelogs/unreleased/-27xkdzq.yml
+++ b/changelogs/unreleased/-27xkdzq.yml
@@ -1,0 +1,6 @@
+---
+title: Improved section-header class styling globally
+ticket_id: "#27xkdzq"
+merge_request: 120
+author: Azkya Khan
+type: changed

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -407,7 +407,7 @@ ion-card {
   }
   
   .section-header {
-    grid: "info tags metadata" / max-content 1fr minmax(min-content, max-content);
+    grid: "info tags metadata" / 1fr max-content 1fr;
   }
 
   .filters {

--- a/src/views/FindProductInventory.vue
+++ b/src/views/FindProductInventory.vue
@@ -368,10 +368,6 @@ export default defineComponent({
     height: 180px;
   }
 
-  .section-header {
-    grid-template-columns: 1fr max-content 1fr;
-  }
-
   .list-item {
     --columns-desktop: 3;
     grid-template-columns: 1fr max-content 1fr;

--- a/src/views/FindPurchaseOrder.vue
+++ b/src/views/FindPurchaseOrder.vue
@@ -239,9 +239,5 @@ export default {
     --columns-desktop: 3;
     grid-template-columns: 1fr max-content 1fr;
   }
-
-  .section-header {
-    grid-template-columns: 1fr max-content 1fr;
-  }
 }
 </style>

--- a/src/views/FindShipment.vue
+++ b/src/views/FindShipment.vue
@@ -239,9 +239,5 @@ export default {
     --columns-desktop: 3;
     grid-template-columns: 1fr max-content 1fr;
   }
-
-  .section-header {
-    grid-template-columns: 1fr max-content 1fr;
-  }
 }
 </style>


### PR DESCRIPTION
### Related Issues
#118 

Closes #118 

### Short Description and Why It's Useful
On the find order screen, the section headers for orders uses a grid formula that causes the order name to not be centered consistently in all orders.


### Screenshots of Visual Changes before/after (If There Are Any)
**Before:**
![before-find-screen](https://user-images.githubusercontent.com/82817616/163986737-c2d07254-4767-41b6-af92-8bd7ad91ca60.png)

**After:**
![after-find-screen](https://user-images.githubusercontent.com/82817616/163986809-4ffe800b-6d44-4bb3-89f9-b84b6f75891d.png)




**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/commerce-hub#contribution-guideline)
