### PR TITLE
Added missing slot on parent product image thumbnail on product inventory page(#28379yc)

### DIFF
--- a/changelogs/unreleased/-28379yc.yml
+++ b/changelogs/unreleased/-28379yc.yml
@@ -1,0 +1,6 @@
+---
+title: Added missing slot on parent product image thumbnail on product inventory page
+ticket_id: "#28379yc"
+merge_request: 132
+author: Azkya Khan
+type: changed

--- a/src/views/ProductInventory.vue
+++ b/src/views/ProductInventory.vue
@@ -44,7 +44,7 @@
         </section>
 
         <ion-item class="mobile-only" lines="none">
-          <ion-thumbnail>
+          <ion-thumbnail slot="start">
             <Image :src="product.mainImage" />
           </ion-thumbnail>
           <ion-label>


### PR DESCRIPTION
### Related Issues
#127 

Closes #127 

### Short Description and Why It's Useful
On the mobile view, the product image for the the parent product on the detail page doesn't correctly use ion item slots which causes the image to be mis-aligned.

### Screenshots of Visual Changes before/after (If There Are Any)
**Before:**
![product-image-before](https://user-images.githubusercontent.com/82817616/164173305-a4ad058d-4218-4b6e-836e-622626c750fc.png)

**After:**
![product-image-after](https://user-images.githubusercontent.com/82817616/164173324-9a43f83a-0b75-4456-994b-acf72e5a28c5.png)

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/commerce-hub#contribution-guideline)
