### PR TITLE
Improved code by emphasizing orderId on find orders page(#2894ay5)

### DIFF
--- a/src/views/FindOrder.vue
+++ b/src/views/FindOrder.vue
@@ -74,7 +74,7 @@
               <div class="primary-info">
                 <ion-item lines="none">
                   <ion-label>
-                    {{ order.orderId }}
+                    <strong>{{ order.orderId }}</strong>
                     <p> {{ order.customer.name }} </p>
                   </ion-label>
                 </ion-item>

--- a/src/views/Order.vue
+++ b/src/views/Order.vue
@@ -18,7 +18,7 @@
           <div class="id">
             <ion-item lines="none">
               <ion-icon slot="start" :icon="ticketOutline" />
-              <h1><strong>{{ order.orderName ? order.orderName : order.orderId }}</strong></h1>
+              <h1>{{ order.orderName ? order.orderName : order.orderId }}</h1>
               <StatusBadge :statusDesc="order.statusDesc || ''" :key="order.statusDesc" slot="end"/>
               <ion-select v-if="validStatusChange(order.statusId)?.length > 0" @ionChange="changeStatus(order.orderId, $event)" slot="end">
                 <ion-select-option v-for="status in validStatusChange(order.statusId)" :key="status" :value="status">{{ orderStatus[status]?.label }}</ion-select-option>

--- a/src/views/Order.vue
+++ b/src/views/Order.vue
@@ -18,7 +18,7 @@
           <div class="id">
             <ion-item lines="none">
               <ion-icon slot="start" :icon="ticketOutline" />
-              <h1>{{ order.orderName ? order.orderName : order.orderId }}</h1>
+              <h1><strong>{{ order.orderName ? order.orderName : order.orderId }}</strong></h1>
               <StatusBadge :statusDesc="order.statusDesc || ''" :key="order.statusDesc" slot="end"/>
               <ion-select v-if="validStatusChange(order.statusId)?.length > 0" @ionChange="changeStatus(order.orderId, $event)" slot="end">
                 <ion-select-option v-for="status in validStatusChange(order.statusId)" :key="status" :value="status">{{ orderStatus[status]?.label }}</ion-select-option>


### PR DESCRIPTION
### Related Issues
#146 

Closes #146

### Short Description and Why It's Useful
The order ID on the find order page should be easier to identify.


### Screenshots of Visual Changes before/after (If There Are Any)

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/commerce-hub#contribution-guideline)
