### PR TITLE
Improved code by making filter button in toolbar visible when aside filter component is hidden(#28u4w63)

### DIFF
--- a/src/views/FindOrder.vue
+++ b/src/views/FindOrder.vue
@@ -12,7 +12,7 @@
           <!-- <ion-button fill="clear">
             <ion-icon slot="icon-only" :icon="downloadOutline" />
           </ion-button> -->
-          <ion-button fill="clear" @click="openOrderFilter()" v-show="filterButton">
+          <ion-button fill="clear" @click="openOrderFilter()" v-show="showFilterButton">
             <ion-icon slot="icon-only" :icon="filterOutline" />
           </ion-button>
         </ion-buttons>
@@ -206,10 +206,20 @@ export default defineComponent ({
       sort: 'orderDate desc',
       showOrderItems: true,
       poIds: {} as any,
-      filterButton: false,
+      showFilterButton: false,
     }
   },
   methods: {
+    showFilters(){
+      const el = document.querySelector('.order-filters') as Element;
+      const observer = new window.IntersectionObserver(([entry]) => {
+        this.showFilterButton = !entry.isIntersecting;
+      }, {
+        root: null
+      })
+      observer.observe(el);
+    },
+
     async sortOrders(value: string) {
       this.sort = value
       await this.store.dispatch('order/updateSort', this.sort)
@@ -265,18 +275,8 @@ export default defineComponent ({
     }
   },
   async mounted() {
-    const el = document.querySelector('.order-filters') as Element;
-    const observer = new window.IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        this.filterButton = false;
-        return
-      }
-        this.filterButton = true;
-      }, {
-      root: null
-    })
-    observer.observe(el);
-      
+    this.showFilters();
+     
     this.store.dispatch('util/fetchShipmentMethods')
     await this.getOrders();
 

--- a/src/views/FindOrder.vue
+++ b/src/views/FindOrder.vue
@@ -266,17 +266,17 @@ export default defineComponent ({
   },
   async mounted() {
     const el = document.querySelector('.order-filters') as Element;
-      const observer = new window.IntersectionObserver(([entry]) => {
-        if (entry.isIntersecting) {
-          this.filterButton = false;
-         return
-        }
-         this.filterButton = true;
-        }, {
-        root: null,
-        threshold: 0.1
-      })
-      observer.observe(el);
+    const observer = new window.IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        this.filterButton = false;
+        return
+      }
+        this.filterButton = true;
+      }, {
+      root: null,
+      threshold: 0.1
+    })
+    observer.observe(el);
       
     this.store.dispatch('util/fetchShipmentMethods')
     await this.getOrders();

--- a/src/views/FindOrder.vue
+++ b/src/views/FindOrder.vue
@@ -273,8 +273,7 @@ export default defineComponent ({
       }
         this.filterButton = true;
       }, {
-      root: null,
-      threshold: 0.1
+      root: null
     })
     observer.observe(el);
       

--- a/src/views/FindOrder.vue
+++ b/src/views/FindOrder.vue
@@ -11,8 +11,8 @@
           </ion-button>
           <!-- <ion-button fill="clear">
             <ion-icon slot="icon-only" :icon="downloadOutline" />
-          </ion-button> -->
-          <ion-button fill="clear" class="mobile-only" @click="openOrderFilter()">
+          </ion-button> --> 
+          <ion-button fill="clear" @click="openOrderFilter()" v-show="filterButton">
             <ion-icon slot="icon-only" :icon="filterOutline" />
           </ion-button>
         </ion-buttons>
@@ -38,7 +38,9 @@
         </section>
 
         <aside class="filters desktop-only">
-          <OrderFilters :poIds="poIds" :shippingMethodOptions="shippingMethodOptions" :orderStatusOptions="orderStatusOptions"/>
+          <div class="order-filters">
+            <OrderFilters :poIds="poIds" :shippingMethodOptions="shippingMethodOptions" :orderStatusOptions="orderStatusOptions"/>
+          </div>
         </aside>
 
         <main>
@@ -65,6 +67,8 @@
               </ion-item>
             </div>
           </section>
+
+         
 
           <!-- Order Item Section -->
           <hr />
@@ -203,7 +207,8 @@ export default defineComponent ({
       orderStatusOptions: [''],
       sort: 'orderDate desc',
       showOrderItems: true,
-      poIds: {} as any
+      poIds: {} as any,
+      filterButton: false,
     }
   },
   methods: {
@@ -262,6 +267,19 @@ export default defineComponent ({
     }
   },
   async mounted() {
+    const el = document.querySelector('.order-filters') as Element;
+      const observer = new window.IntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+          this.filterButton = false;
+         return
+        }
+         this.filterButton = true;
+        }, {
+        root: null,
+        threshold: 0.1
+      })
+      observer.observe(el);
+      
     this.store.dispatch('util/fetchShipmentMethods')
     await this.getOrders();
 

--- a/src/views/FindOrder.vue
+++ b/src/views/FindOrder.vue
@@ -11,7 +11,7 @@
           </ion-button>
           <!-- <ion-button fill="clear">
             <ion-icon slot="icon-only" :icon="downloadOutline" />
-          </ion-button> --> 
+          </ion-button> -->
           <ion-button fill="clear" @click="openOrderFilter()" v-show="filterButton">
             <ion-icon slot="icon-only" :icon="filterOutline" />
           </ion-button>
@@ -67,8 +67,6 @@
               </ion-item>
             </div>
           </section>
-
-         
 
           <!-- Order Item Section -->
           <hr />


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
The filter menu button in the toolbar is visible when the aside filter component is hidden during scrolling.


### Screenshots of Visual Changes before/after (If There Are Any)
https://user-images.githubusercontent.com/82817616/165293338-54018683-08ed-401d-a222-1c17e98c09bb.mp4


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/commerce-hub#contribution-guideline)
